### PR TITLE
FIx e-mail address markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Department of Technology at Watchout** is looking for **full-time or part-time web developers**.
 
-Open an issue at [this repo](https://github.com/watchout-tw/jobs/) **OR** contact [dev@watchout.tw](#) for more details and appointment.
+Open an issue at [this repo](https://github.com/watchout-tw/jobs/) **OR** contact <dev@watchout.tw> for more details and appointment.
 
 ## Our passion
 - Want to code good


### PR DESCRIPTION
Just in case it isn't done intended, feel free to reject the patch.

Signed-off-by: Ｖ字龍 &lt;<Vdragon.Taiwan@gmail.com>&gt;